### PR TITLE
fix(edge): enable /blog and update GQL calls

### DIFF
--- a/src/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/__snapshots__/index.test.tsx.snap
@@ -139,6 +139,16 @@ exports[`Home renders a snapshot of the homepage 1`] = `
           Let's Work Together!
         </a>
       </li>
+      <li>
+        <a
+          aria-label=""
+          class="hover:text-gray-800 rounded-sm hover:bg-orange-300 py-2 px-20 no-underline"
+          href="/blog"
+          role="link"
+        >
+          Recent Articles
+        </a>
+      </li>
     </ul>
   </nav>
   <main

--- a/src/__tests__/components/__snapshots__/__snapshots__/layouts.test.tsx.snap
+++ b/src/__tests__/components/__snapshots__/__snapshots__/layouts.test.tsx.snap
@@ -142,6 +142,16 @@ exports[`<Layout /> matches snapshot 1`] = `
               Let's Work Together!
             </a>
           </li>
+          <li>
+            <a
+              aria-label=""
+              class="hover:text-gray-800 rounded-sm hover:bg-orange-300 py-2 px-20 no-underline"
+              href="/blog"
+              role="link"
+            >
+              Recent Articles
+            </a>
+          </li>
         </ul>
       </nav>
       <main
@@ -570,6 +580,16 @@ exports[`<Layout /> matches snapshot 1`] = `
             role="link"
           >
             Let's Work Together!
+          </a>
+        </li>
+        <li>
+          <a
+            aria-label=""
+            class="hover:text-gray-800 rounded-sm hover:bg-orange-300 py-2 px-20 no-underline"
+            href="/blog"
+            role="link"
+          >
+            Recent Articles
           </a>
         </li>
       </ul>

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -65,7 +65,7 @@ export const Nav: React.FC<NavProps> = ({ className }) => {
             Let&apos;s Work Together!
           </Link>
         </li>
-        {/* <li>
+        <li>
           <Link
             href='/blog'
             aria-label='Recent Articles'
@@ -73,7 +73,7 @@ export const Nav: React.FC<NavProps> = ({ className }) => {
           >
             Recent Articles
           </Link>
-        </li> */}
+        </li>
         {/* <li>
           <Link href='/uses' aria-label='Uses' className={anchorClass}>
             Uses

--- a/src/utils/fetch-posts.ts
+++ b/src/utils/fetch-posts.ts
@@ -1,4 +1,4 @@
-import { gql, request } from 'graphql-request';
+import { gql, GraphQLClient } from 'graphql-request';
 
 const GET_USER_ARTICLES = gql`
   query GetUserArticles($page: Int!) {
@@ -39,10 +39,14 @@ type Post = {
 };
 
 export async function fetchUserArticles(page: number): Promise<Post[]> {
-  const url = 'https://api.hashnode.com';
-  const data = await request<UserArticlesResponse>(url, GET_USER_ARTICLES, {
-    page
-  });
+  const endpoint = 'https://api.hashnode.com';
+
+  const graphQLClient = new GraphQLClient(endpoint, { fetch });
+  const data = await graphQLClient.request<UserArticlesResponse>(
+    GET_USER_ARTICLES,
+    { page }
+  );
+
   const postsArray = data.user.publication.posts.map((post) => {
     return {
       title: post.title,


### PR DESCRIPTION
The error was seen in CF deployment logs:

```js
{
  "outcome": "ok",
  "scriptName": "pages-worker--13208-production",
  "exceptions": [],
  "logs": [
    {
      "message": [
        "ReferenceError: XMLHttpRequest is not defined"
      ],
      "level": "error",
      "timestamp": 1681343675036
    }
  ],
...
```

GQL client needs to be initialized with `fetch`, otherwise it defaults to `XMLHttpRequest`